### PR TITLE
Fix wrong path

### DIFF
--- a/templates/default/run_mysql_backup.erb
+++ b/templates/default/run_mysql_backup.erb
@@ -6,7 +6,7 @@
 
 
 # run backup
-<%= node['automysqlbackup']['bin_path'] %>automysqlbackup <%= node['automysqlbackup']['config_path'] %>/<%= node['automysqlbackup']['config'] %>.conf
+<%= node['automysqlbackup']['bin_path'] %>/automysqlbackup <%= node['automysqlbackup']['config_path'] %>/<%= node['automysqlbackup']['config'] %>.conf
 
 # set mode to backup
 chown -R <%= node['automysqlbackup']['user'] %>:<%= node['automysqlbackup']['group'] %> <%= node['automysqlbackup']['backup_dir'] %>


### PR DESCRIPTION
This PR fixes the following error:

```
root@mysql:~# crontab -l
# Chef Name: run_mysql_backup
1 0 * * * /usr/bin/run_mysql_backup >/dev/null 2>&1 | logger -t automysqlbackup
root@mysql:~# /usr/bin/run_mysql_backup
/usr/bin/run_mysql_backup: 9: /usr/bin/run_mysql_backup: /usr/binautomysqlbackup: not found
root@mysql:~# cat /usr/bin/run_mysql_backup
#!/bin/sh
# WARNING
# THIS FILE WAS AUTOGENERATED BY CHEF FOR mysql
# YOUR CHANGES will BE OVERWRITTEN
# EDIT AT YOUR OWN RISK


# run backup
/usr/binautomysqlbackup /etc/automysqlbackup/myserver.conf

# set mode to backup
chown -R : /var/backup/db

find /var/backup/db -type f -exec chmod 400 {} \;
find /var/backup/db -type d -exec chmod 700 {} \;
```