### PR TITLE
Fixing wrong variable name

### DIFF
--- a/templates/default/run_mysql_backup.erb
+++ b/templates/default/run_mysql_backup.erb
@@ -9,7 +9,7 @@
 <%= node['automysqlbackup']['bin_path'] %>/automysqlbackup <%= node['automysqlbackup']['config_path'] %>/<%= node['automysqlbackup']['config'] %>.conf
 
 # set mode to backup
-chown -R <%= node['automysqlbackup']['user'] %>:<%= node['automysqlbackup']['group'] %> <%= node['automysqlbackup']['backup_dir'] %>
+chown -R <%= node['automysqlbackup']['dump']['user'] %>:<%= node['automysqlbackup']['dump']['group'] %> <%= node['automysqlbackup']['backup_dir'] %>
 
 <% if node['automysqlbackup']['secure_backups'] %>
 find <%= node['automysqlbackup']['backup_dir'] %> -type f -exec chmod 400 {} \;


### PR DESCRIPTION
This fix the **set mode to backup** not getting the right values.

```
federico@mysql:~$ cat /usr/bin/run_mysql_backup
[...]

# set mode to backup
chown -R : /var/backup/db

[...]
```