### PR TITLE
Unused database cookbook dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Dependencies
 
 This cookbook depends on the following community cookbooks.
 
-* database
 * mysql
 
 Platform

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,6 @@ version '2.0.1'
   supports os
 end
 
-%w(mysql database).each do |ressource|
+%w(mysql).each do |ressource|
   depends ressource
 end


### PR DESCRIPTION
I cant find a place where the dependency is used in the cookbook, and since it's deprecated i think it's bad form to force cookboo users to include it.